### PR TITLE
FIX: Segmentation fault on macOS Sierra and High Sierra

### DIFF
--- a/src/miner/delegator.rs
+++ b/src/miner/delegator.rs
@@ -297,7 +297,9 @@ impl Delegator {
 		}
 		for l in self.libraries.read().unwrap().iter() {
 			//wait for internal processing to finish
-			while l.call_cuckoo_has_processing_stopped()==0{};
+			while l.call_cuckoo_has_processing_stopped()==0{
+				thread::sleep(time::Duration::from_millis(1));
+			};
 			l.call_cuckoo_reset_processing();
 		}
 		let mut s = self.control_data.write().unwrap();

--- a/src/miner/miner.rs
+++ b/src/miner/miner.rs
@@ -277,6 +277,7 @@ impl CuckooMinerJobHandle {
 			if r.has_stopped {
 				break;
 			}
+			thread::sleep(time::Duration::from_millis(1));
 		}
 		debug!("All jobs have stopped");
 	}


### PR DESCRIPTION
(1)fix in submodule `cuckoo`: Segmentation fault on macOS Sierra and High Sierra. - https://github.com/mimblewimble/grin-miner/issues/2
The related pull-request on repo `cuckoo` is [#2](https://github.com/mimblewimble/cuckoo/pull/2)

(2)stop_jobs() improvement: sleep 1ms in while loop, to avoid the tough infinite loop eat up all the cpu.