### PR TITLE
Fix lock and timing

### DIFF
--- a/src/miner/miner.rs
+++ b/src/miner/miner.rs
@@ -272,11 +272,13 @@ impl CuckooMinerJobHandle {
 		}
 		debug!("Stop jobs flag set");
 		loop {
-			let r = self.control_data.read().unwrap();
-			if r.has_stopped {
-				break;
+			{
+				let r = self.control_data.read().unwrap();
+				if r.has_stopped {
+					break;
+				}
 			}
-			thread::sleep(time::Duration::from_millis(1));
+			thread::sleep(time::Duration::from_millis(5));
 		}
 		debug!("All jobs have stopped");
 	}


### PR DESCRIPTION
Currently the read lock is almost never dropped as it's held during the sleep time. So the write lock in the delegator to exit the main loop is never acquired.
Also changed the wait time to limit lock contention.
Ideally, it might be better to use an AtomicBool instead of locking the whole structure.